### PR TITLE
docs: add project overview and tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# KnowBuddy
+
+## Purpose & Functionality
+KnowBuddy demonstrates how to build a small, memory-enabled ReAct agent. The main script wires an Anthropic Claude model into a LangChain/LangGraph workflow, equips it with a Tavily search tool, and streams responses to user prompts. A minimal `demo.py` is provided as a simple console demo.
+
+## Tech Stack
+- Python
+- LangChain
+- LangGraph
+- Anthropic's Claude via `ChatAnthropic`
+- Tavily search integration
+- Jupyter notebooks for experimentation
+
+## Next Vision
+- Add more tools for expanded capabilities (e.g., calculators, databases)
+- Build a user-facing interface for interaction
+- Explore deploying agents with open-source models


### PR DESCRIPTION
## Summary
- document KnowBuddy's purpose and functionality
- list tech stack including LangChain, LangGraph, and Tavily search
- outline next vision for future enhancements

## Testing
- `pytest` *(no tests found)*
